### PR TITLE
ci: Release helm charts as OCI artifact

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,3 +33,21 @@ jobs:
           config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      # see https://github.com/helm/chart-releaser/issues/183
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          done


### PR DESCRIPTION
Helm supports helm charts as OCI artifact, too. This has the great benefit that a local configuration of a helm repo is not longer necessary.

Ref: https://github.com/prometheus-community/helm-charts/blob/17736adc63d50adefa7d8e00db6ade82bb2dce94/.github/workflows/release.yaml#L45C1-L61C15