### PR TITLE
General chart improvements

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - private
 - realtime
 type: application
-version: 0.2.8
+version: 0.3.0
 appVersion: "0.1.9"
 home: https://github.com/kubetail-org/kubetail
 maintainers:

--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -88,3 +88,14 @@ ServiceAccount name
 {{- define "kubetail.serviceAccountName" -}}
 {{ if .Values.serviceAccount.name }}{{ .Values.serviceAccount.name }}{{ else }}{{ include "kubetail.fullname" . }}{{ end }}
 {{- end }}
+
+{{/*
+config
+*/}}
+{{- define "kubetail.config" -}}
+addr: :{{ .Values.deployment.containerPort }}
+auth-mode: {{ .Values.authMode }}
+{{- with .Values.config }}
+{{- tpl (toYaml .) $ | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/charts/kubetail/templates/config-map.yaml
+++ b/charts/kubetail/templates/config-map.yaml
@@ -7,8 +7,5 @@ metadata:
     {{- include "kubetail.labels" $ | nindent 4 }}
 data:
   config.yaml: |
-    addr: :{{ .Values.deployment.containerPort }}
-    auth-mode: {{ .Values.authMode }}
-{{- with .Values.config }}
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- include "kubetail.config" $ | nindent 4 }}
+

--- a/charts/kubetail/templates/deployment.yaml
+++ b/charts/kubetail/templates/deployment.yaml
@@ -16,14 +16,22 @@ spec:
       labels:
         {{- include "kubetail.labels" $ | nindent 8 }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
+        checksum/config: {{ include "kubetail.config" . | sha256sum }}
+        {{- with .Values.deployment.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}
       {{- if eq .Values.authMode "cluster" }}
       serviceAccountName: {{ include "kubetail.serviceAccountName" . }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.deployment.podSecurityContext | nindent 8 }}
       containers:
       - name: kubetail
         image: {{ .Values.image.registry }}:{{ default .Chart.AppVersion .Values.image.tag }}
+        securityContext:
+          {{- toYaml .Values.deployment.securityContext | nindent 10 }}
         {{- if .Values.image.pullPolicy }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- end }}
@@ -35,9 +43,17 @@ spec:
         {{- range .Values.deployment.args }}
         - {{ . }}
         {{- end }}
+        {{- if .Values.deployment.livenessProbe.enabled }}
         {{- with .Values.deployment.livenessProbe }}
         livenessProbe:
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml (omit . "enabled") | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.deployment.readinessProbe.enabled }}
+        {{- with .Values.deployment.readinessProbe }}
+        readinessProbe:
+          {{- toYaml (omit . "enabled") | nindent 10 }}
+        {{- end }}
         {{- end }}
         {{- with .Values.deployment.resources }}
         resources:
@@ -47,6 +63,21 @@ spec:
         - name: config
           mountPath: /etc/kubetail
           readOnly: true
+      {{- with .Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/charts/kubetail/templates/ingress.yaml
+++ b/charts/kubetail/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   rules:
   {{- range $ing.hosts }}
-  - host: {{ .host }}
+  - host: {{ tpl .host $ }}
     http:
       paths:
       {{- range .paths }}
@@ -29,9 +29,9 @@ spec:
   {{- range . }}
   - hosts:
     {{- range .hosts }}
-    - {{ . }}
+    - {{ tpl . $ }}
     {{- end }}
-    secretName: {{ if $ing.secretName }}{{ $ing.secretName }}{{ else }}{{ include "kubetail.fullname" $ }}{{ end }}
+    secretName: {{ if $ing.secretName }}{{ tpl $ing.secretName $ }}{{ else }}{{ include "kubetail.fullname" $ }}{{ end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/kubetail/templates/service-account.yaml
+++ b/charts/kubetail/templates/service-account.yaml
@@ -1,7 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
   {{- include "kubetail.metadataNamespace" $ | nindent 2 }}
   name: {{ include "kubetail.serviceAccountName" . }}
   labels:
     {{- include "kubetail.labels" $ | nindent 4 }}
+{{- end }}

--- a/charts/kubetail/templates/service.yaml
+++ b/charts/kubetail/templates/service.yaml
@@ -5,10 +5,16 @@ metadata:
   name: {{ if .Values.service.name }}{{ .Values.service.name }}{{ else }}{{ include "kubetail.fullname" . }}{{ end }}
   labels:
     {{- include "kubetail.labels" $ | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   selector:
     {{- include "kubetail.selectorLabels" $ | nindent 4 }}
   ports:
   - port: {{ .Values.service.port }}
+    name: kubetail
     targetPort: kubetail
+    appProtocol: http

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -65,6 +65,17 @@ deployment:
   args:
   - --config=/etc/kubetail/config.yaml
   livenessProbe:
+    enabled: true
+    httpGet:
+      scheme: HTTP
+      path: /healthz
+      port: 4000
+    initialDelaySeconds: 30
+    timeoutSeconds: 30
+    periodSeconds: 10
+    failureThreshold: 3
+  readinessProbe:
+    enabled: true
     httpGet:
       scheme: HTTP
       path: /healthz
@@ -77,16 +88,41 @@ deployment:
     requests:
       cpu: 100m
       memory: 100Mi
+  automountServiceAccountToken: true
+  podAnnotations: {}
+  podSecurityContext:
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  affinity: {}
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations: {}
+  priorityClassName: ""
 
 # service options
 service:
+  annotations: {}
   name:
   type: ClusterIP
   port: 4000
 
 # service-account options
 serviceAccount:
-  name:
+  create: true
+  annotations: {}
+  name: ""
+  automountServiceAccountToken: false
 
 # ingress options
 ingress:


### PR DESCRIPTION
Hi,

I added many options to this helm chart now. Some of them base on good-pratice. Taken from other helm charts. 

If you feel, this is too big, I will cut them into smaller PRs.

* Support for namespace scoped deployments: A new option `rbac.namespaced` is introduced. if true, Role and Rolebinding will be created instead ClusterRole/ClusterRoleBinding. I also change from the values from `clusterRole.name` and `clusterRoleBinding.name` to `rbac.roleName` and `rbac.roleBindingName`. The old name still working.
* Avoid unnecessary restarts at new helm version: The ConfigMap where the config is stored, contains labels. The labels contains the version of the helm chart. If there is a new helm chart version, the pod gets restarted, too. It doesnt matter, if its necessary or not. To solve this, I moved the config to a named templated which can be sourced from the config map and the hash annotation. I contribute this pattern to many helm charts: (https://github.com/grafana/helm-charts/pull/2833, https://github.com/bitnami/charts/pull/21489, https://github.com/prometheus-community/helm-charts/pull/4077, https://github.com/kubernetes-sigs/external-dns/pull/4103)
* Added securityContexts to container and pod. They contains the current best-practice. The settings are required to run kubelint together with [PSA restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
* Added `automountServiceAccountToken` to the Deployment and ServiceAccount. A lot of security tools hightlight automountServiceAccountToken=true on a ServiceAccount as insecure. The best-practice is to set automountServiceAccountToken=false on a ServiceAccount and do automountServiceAccountToken=true on the Deployment. Ref: https://securecloud.blog/2021/08/17/azure-aks-reviewing-recommendations-from-security-center-disabling-automounting-api-credentials
* Added `nodeSelector`, `affinity`, `tolerations`, `priorityClassName`. I currently need `nodeSelector` only because we have mixed OS clusters. `tolerations` is needed, because infra-nodes have taints sometimes.
* Pass `.Values.config`, `.Values.ingress.hosts.hosts` through helm tpl function: If kubelint is part of a bigger umbrella helm chart, values from `.Values.global` can be re-used. It's also useful for the `namespace` option

Non-resolved issues:

* There is no readinessProbe, but some enterprise policy may require one. It doesn't matter if it make sense, rule is rule.
* The Cookie Secret are stored inside a ConfigMap, but they should be stored inside a Kubernetes secret (any mount them via ENV variable. I can provide this in a follow-up PR.

I have tested the helm chart with `helm upgrade kubetail . --set rbac.namespaced=false`, `helm upgrade kubetail . --set rbac.namespaced=true --set-string config.namespace='\{\{ .Release.Namespace \}\}`